### PR TITLE
Update VIPER link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Small project using a master and detail view
 
 Demonstrates the use of the following features:
 
-- VIPER architecture (http://mutualmobile.github.io/blog/2013/12/04/viper-introduction/)
+- VIPER architecture (https://mutualmobile.com/posts/meet-viper-fast-agile-non-lethal-ios-architecture-framework)
 - MagicalRecord (Core Data Framework, https://github.com/magicalpanda/MagicalRecord)
 - Typhoon (Dependency Injection, http://www.typhoonframework.org)
 


### PR DESCRIPTION
This pull request fixes a link in the README

Created with [`readme-correct`](https://github.com/dkhamsing/readme-correct).
